### PR TITLE
Fix Java 1.8 NoSuchMethodError: java.nio.ByteBuffer.flip()

### DIFF
--- a/caliper-util/src/main/java/com/google/caliper/util/Uuids.java
+++ b/caliper-util/src/main/java/com/google/caliper/util/Uuids.java
@@ -34,11 +34,12 @@ public final class Uuids {
   private Uuids() {}
 
   /** Returns a buffer containing the 16 bytes of the given UUID. */
+  @SuppressWarnings("RedundantCast")
   public static ByteBuffer toBytes(UUID uuid) {
     ByteBuffer buf = ByteBuffer.allocate(UUID_BYTES);
     buf.putLong(uuid.getMostSignificantBits());
     buf.putLong(uuid.getLeastSignificantBits());
-    buf.flip();
+    ((java.nio.Buffer) buf).flip();  // for Java 1.8 compatibility
     return buf;
   }
 
@@ -57,6 +58,7 @@ public final class Uuids {
   }
 
   /** Reads the next 16 bytes from the given channel as a UUID. */
+  @SuppressWarnings("RedundantCast")
   public static UUID readFromChannel(ReadableByteChannel channel) throws IOException {
     ByteBuffer buf = ByteBuffer.allocate(UUID_BYTES);
     while (buf.hasRemaining()) {
@@ -64,7 +66,7 @@ public final class Uuids {
         throw new EOFException("unexpected EOF while reading UUID");
       }
     }
-    buf.flip();
+    ((java.nio.Buffer) buf).flip();  // for Java 1.8 compatibility
     return fromBytes(buf);
   }
 }


### PR DESCRIPTION
The following error in the worker happens under **Java 1.8**:

[stderr] Exception in thread "main" java.lang.IllegalStateException: Expected the service ClientConnectionService [FAILED] to be RUNNING, but the service has FAILED
[stderr] at com.google.common.util.concurrent.AbstractService.checkCurrentState(AbstractService.java:379)
[stderr] at com.google.common.util.concurrent.AbstractService.awaitRunning(AbstractService.java:303)
[stderr] at com.google.common.util.concurrent.AbstractIdleService.awaitRunning(AbstractIdleService.java:164)
[stderr] at com.google.caliper.worker.Worker.run(Worker.java:42)
[stderr] at com.google.caliper.worker.WorkerMain.main(WorkerMain.java:30)
[stderr] Caused by: java.lang.NoSuchMethodError: java.nio.ByteBuffer.flip()Ljava/nio/ByteBuffer;
[stderr] at com.google.caliper.util.Uuids.toBytes(Uuids.java:41)
[stderr] at com.google.caliper.util.Uuids.writeToChannel(Uuids.java:47)
[stderr] at com.google.caliper.worker.connection.ClientConnectionService.startUp(ClientConnectionService.java:55)
[stderr] at com.google.common.util.concurrent.AbstractIdleService$DelegateService$1.run(AbstractIdleService.java:61)
[stderr] at com.google.common.util.concurrent.Callables$4.run(Callables.java:119)
[stderr] at java.lang.Thread.run(Thread.java:748)

The applied workaround in https://stackoverflow.com/a/61267496 (Approach 2).